### PR TITLE
FIX: 画像変換エラーの対応・大容量ファイルのpresigned URLアップロード対応

### DIFF
--- a/backend/app/api/convert.py
+++ b/backend/app/api/convert.py
@@ -1,4 +1,5 @@
 import io
+import uuid
 import zipfile
 from pathlib import Path
 from typing import Any
@@ -28,43 +29,89 @@ def _validate_file(filename: str) -> None:
         )
 
 
+@router.post("/presign-upload")
+async def presign_upload(
+    filename: str = Form(...),
+) -> dict[str, Any]:
+    """S3への直接アップロード用の署名付きURLを返す（API Gateway 10MB 制限回避用）。
+
+    大きなファイル（>8MB）はこのエンドポイントで URL を取得し、
+    クライアントから直接 S3 に PUT してから /convert に s3_key を渡す。
+    """
+    if not settings.use_aws:
+        raise HTTPException(status_code=400, detail="ローカルモードでは使用できません")
+
+    _validate_file(filename)
+
+    from app.services.storage import S3Storage
+
+    storage = S3Storage(settings.s3_bucket, settings.aws_region)
+    job_id = str(uuid.uuid4())
+    upload_url, s3_key = storage.generate_presigned_upload_url(filename, job_id)
+
+    return {"upload_url": upload_url, "s3_key": s3_key, "job_id": job_id}
+
+
 @router.post("/convert")
 async def start_conversion(
-    file: UploadFile = File(...),
+    file: UploadFile | None = File(default=None),
+    s3_key: str | None = Form(default=None),
+    original_filename: str | None = Form(default=None),
     target_size_kb: int | None = Form(None),
     quality: int = Form(settings.default_quality),
     max_delta_e: float = Form(settings.max_delta_e),
 ) -> dict[str, Any]:
-    """ファイルをアップロードして変換ジョブを開始する"""
-    _validate_file(file.filename or "")
+    """ファイルをアップロードして変換ジョブを開始する。
 
-    content = await file.read()
-    if len(content) > settings.max_upload_size_mb * 1024 * 1024:
-        raise HTTPException(
-            status_code=413,
-            detail=f"ファイルサイズが大きすぎます。{settings.max_upload_size_mb}MB以下のファイルをご使用ください",
-        )
-
+    2つのモードをサポート:
+    1. 直接アップロード: file パラメータでファイルを送信（最大 8MB）
+    2. S3キー指定: /presign-upload で取得した s3_key を指定（大きなファイル用）
+    """
     options = ConversionOptions(
         target_size_kb=target_size_kb,
         quality=quality,
         max_delta_e=max_delta_e,
     )
-    original_filename = file.filename or "upload"
 
     if settings.use_aws:
-        # AWSモード: S3にアップロードしてSQSキューに投入
         from app.services.storage import S3Storage
-        import uuid
 
         storage = S3Storage(settings.s3_bucket, settings.aws_region)
-        job_id = str(uuid.uuid4())
-        input_s3_key = await storage.save_upload(content, original_filename, job_id)
-        job = await job_queue.enqueue(input_s3_key, options, original_filename)
+
+        if s3_key:
+            # Presigned URL アップロード済みファイルをそのまま使用
+            if not original_filename:
+                raise HTTPException(status_code=422, detail="original_filename が必要です")
+            _validate_file(original_filename)
+            job = await job_queue.enqueue(s3_key, options, original_filename)
+        elif file is not None:
+            # 直接アップロード（8MB 以下）
+            _validate_file(file.filename or "")
+            content = await file.read()
+            if len(content) > settings.max_upload_size_mb * 1024 * 1024:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"ファイルサイズが大きすぎます。{settings.max_upload_size_mb}MB以下のファイルをご使用ください",
+                )
+            fname = file.filename or "upload"
+            job_id = str(uuid.uuid4())
+            input_s3_key = await storage.save_upload(content, fname, job_id)
+            job = await job_queue.enqueue(input_s3_key, options, fname)
+        else:
+            raise HTTPException(status_code=422, detail="file または s3_key を指定してください")
     else:
-        # ローカルモード: ローカルファイルシステムに保存
-        input_path = await file_manager.save_upload(content, original_filename)
-        job = await job_queue.enqueue(input_path, options, original_filename)
+        # ローカルモード
+        if file is None:
+            raise HTTPException(status_code=422, detail="ローカルモードでは file が必要です")
+        _validate_file(file.filename or "")
+        content = await file.read()
+        if len(content) > settings.max_upload_size_mb * 1024 * 1024:
+            raise HTTPException(
+                status_code=413,
+                detail=f"ファイルサイズが大きすぎます。{settings.max_upload_size_mb}MB以下のファイルをご使用ください",
+            )
+        input_path = await file_manager.save_upload(content, file.filename or "upload")
+        job = await job_queue.enqueue(input_path, options, file.filename or "upload")
 
     return {"job_id": job.job_id, "status": job.status}
 

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -8,6 +8,9 @@ import botocore
 class S3Storage:
     """S3ベースのファイルストレージ"""
 
+    # API Gateway の 10MB ペイロード制限を回避するための閾値
+    DIRECT_UPLOAD_LIMIT_BYTES = 8 * 1024 * 1024  # 8MB
+
     def __init__(self, bucket: str, region: str = "ap-northeast-1") -> None:
         self.bucket = bucket
         self.s3 = boto3.client("s3", region_name=region)
@@ -39,6 +42,26 @@ class S3Storage:
     def upload_from_path(self, local_path: str, key: str) -> None:
         """ローカルファイルをS3にアップロードする。"""
         self.s3.upload_file(local_path, self.bucket, key, ExtraArgs={"ContentType": "image/jpeg"})
+
+    def generate_presigned_upload_url(
+        self, filename: str, job_id: str, expires_in: int = 300
+    ) -> tuple[str, str]:
+        """S3への直接アップロード用の署名付きURLを生成する。
+
+        API Gateway の 10MB 制限を超えるファイルに使用する。
+
+        Returns:
+            (upload_url, s3_key) のタプル
+        """
+        ext = Path(filename).suffix.lower()
+        key = f"input/{job_id}/{uuid.uuid4().hex}{ext}"
+        upload_url = self.s3.generate_presigned_url(
+            "put_object",
+            Params={"Bucket": self.bucket, "Key": key},
+            ExpiresIn=expires_in,
+            HttpMethod="PUT",
+        )
+        return upload_url, key
 
     def generate_presigned_url(self, key: str, expires_in: int = 3600) -> str:
         """S3オブジェクトの署名付きURLを生成する。

--- a/backend/worker_handler.py
+++ b/backend/worker_handler.py
@@ -135,12 +135,12 @@ def _process_job(
 
         except Exception as e:
             logger.exception("ジョブ %s の変換中にエラーが発生しました", job_id)
+            error_detail = str(e) if str(e) else type(e).__name__
             repo.update_job_status(
                 job_id=job_id,
                 status="failed",
                 progress=0,
                 progress_message="変換失敗",
-                error="変換中にエラーが発生しました。しばらく経ってから再度お試しください。",
+                error=f"変換中にエラーが発生しました: {error_detail}",
             )
             storage.delete_object(input_s3_key)
-            raise

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,10 +17,67 @@ async function handleResponse<T>(response: Response): Promise<T> {
   return response.json()
 }
 
+// API Gateway の 10MB ペイロード制限を考慮して 8MB 超は presigned URL フローを使用
+const DIRECT_UPLOAD_LIMIT = 8 * 1024 * 1024
+
+async function uploadViaPresignedUrl(
+  file: File,
+  options: ConversionOptions
+): Promise<ConversionJob> {
+  // Step 1: presigned URL を取得
+  const presignFormData = new FormData()
+  presignFormData.append('filename', file.name)
+  const presignRes = await fetch(`${API_BASE}/presign-upload`, {
+    method: 'POST',
+    body: presignFormData,
+  })
+  const { upload_url, s3_key } = await handleResponse<{
+    upload_url: string
+    s3_key: string
+    job_id: string
+  }>(presignRes)
+
+  // Step 2: S3 に直接 PUT アップロード
+  const putRes = await fetch(upload_url, {
+    method: 'PUT',
+    body: file,
+    headers: { 'Content-Type': 'application/octet-stream' },
+  })
+  if (!putRes.ok) {
+    throw new Error(`S3 アップロードに失敗しました: HTTP ${putRes.status}`)
+  }
+
+  // Step 3: 変換ジョブを開始
+  const convertFormData = new FormData()
+  convertFormData.append('s3_key', s3_key)
+  convertFormData.append('original_filename', file.name)
+  if (options.targetSizeKb) {
+    convertFormData.append('target_size_kb', String(options.targetSizeKb))
+  }
+  convertFormData.append('quality', String(options.quality))
+  convertFormData.append('max_delta_e', String(options.maxDeltaE))
+
+  const convertRes = await fetch(`${API_BASE}/convert`, {
+    method: 'POST',
+    body: convertFormData,
+  })
+  const data = await handleResponse<{ job_id: string; status: string }>(convertRes)
+  return {
+    jobId: data.job_id,
+    status: data.status as ConversionJob['status'],
+    createdAt: new Date().toISOString(),
+  }
+}
+
 export async function startConversion(
   file: File,
   options: ConversionOptions
 ): Promise<ConversionJob> {
+  // 8MB 超のファイルは presigned URL 経由でアップロード（API Gateway 10MB 制限回避）
+  if (file.size > DIRECT_UPLOAD_LIMIT) {
+    return uploadViaPresignedUrl(file, options)
+  }
+
   const formData = new FormData()
   formData.append('file', file)
   if (options.targetSizeKb) {

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -34,6 +34,19 @@ resource "aws_s3_bucket_public_access_block" "uploads" {
   restrict_public_buckets = true
 }
 
+# ブラウザから presigned URL で直接 PUT アップロードするための CORS 設定
+resource "aws_s3_bucket_cors_configuration" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+
 # 24時間後にファイルを自動削除するライフサイクルルール
 resource "aws_s3_bucket_lifecycle_configuration" "uploads" {
   bucket = aws_s3_bucket.uploads.id


### PR DESCRIPTION
## 概要
API Gateway の 10MB ペイロード制限によって発生していた大容量ファイル（>8MB）の変換エラーを修正。8MB超のファイルは presigned URL 経由で S3 に直接アップロードするフローを追加。

## 関連タスク
- #9

## やったこと
- `/presign-upload` エンドポイントを新規追加（S3 presigned PUT URL の発行）
- `/convert` エンドポイントに `s3_key` + `original_filename` による変換開始モードを追加
- フロントエンドで 8MB 超のファイルを自動的に presigned URL フロー経由でアップロードするよう切り替え
- S3 バケットに CORS 設定を追加（ブラウザからの直接 PUT を許可）
- worker エラーメッセージに例外詳細を含めるよう修正（デバッグ性向上）

## やらないこと
- 認証・認可の実装（API 全体で未実装のため対象外）
- ファイルの magic bytes バリデーション

## 影響範囲
- `backend/app/api/convert.py` — エンドポイント追加・変更
- `backend/app/services/storage.py` — presigned URL 生成メソッド追加
- `backend/worker_handler.py` — エラーメッセージ改善
- `frontend/src/api/client.ts` — 大容量ファイルのアップロードフロー切り替え
- `infra/s3.tf` — S3 CORS 設定追加

## テスト
- [ ] 8MB 以下のファイル: 直接アップロードフローで変換成功
- [ ] 8MB 超のファイル: presigned URL フロー経由で変換成功
- [ ] `.ai` / `.psd` 以外の拡張子: 422 エラーが返ること

## スクショまたは動画
（動作確認後に追記）

## 備考
presigned URL の有効期限は 300 秒（5分）。期限切れの場合はユーザーが再度アップロード操作を行う必要がある。